### PR TITLE
Cool sound remains, but less obnoxious

### DIFF
--- a/src/main/java/com/glisco/disenchanter/client/DisenchanterClient.java
+++ b/src/main/java/com/glisco/disenchanter/client/DisenchanterClient.java
@@ -21,7 +21,7 @@ public class DisenchanterClient implements ClientModInitializer {
         ClientPlayNetworking.registerGlobalReceiver(new Identifier(Disenchanter.MOD_ID, "disenchant_event"), (client, handler, buf, responseSender) -> {
             var pos = buf.readBlockPos();
             client.execute(() -> {
-                client.player.playSound(SoundEvents.ITEM_TOTEM_USE, SoundCategory.MASTER, .75f, .8f + client.world.random.nextFloat() * .4f);
+                client.player.playSound(SoundEvents.ITEM_TOTEM_USE, SoundCategory.BLOCKS, .5f, .8f + client.world.random.nextFloat() * .4f);
 
                 for (int i = 0; i < 100; i++) {
                     client.world.addParticle(ParticleTypes.LAVA, pos.getX() + 0.5, pos.getY() + 0.685, pos.getZ() + 0.5, 0, 0, 0);


### PR DESCRIPTION
Sound category changed to BLOCKS, volume reduced by default.

This will help make this block much less obnoxious on servers. As of right now, it is very loud and annoying for others on servers, especially when disenchanting multiple items in a row.

Unchanged but suspected issue:
ITEM_TOTEM_USE is playing for every client that has the chunks loaded as well, perhaps this is due to client.player.playSound calling on every client and not just the block user?