### PR TITLE
Catalyst items are configureable

### DIFF
--- a/src/main/java/com/glisco/disenchanter/catalyst/CatalystRegistry.java
+++ b/src/main/java/com/glisco/disenchanter/catalyst/CatalystRegistry.java
@@ -17,7 +17,7 @@ public final class CatalystRegistry {
 
     private static final Map<Item, CatalystEntry> REGISTRY = new HashMap<>();
 
-    public static void register( DisenchanterConfig.CatalystConfig config, Catalyst catalyst) {
+    public static void register(DisenchanterConfig.CatalystConfig config, Catalyst catalyst) {
         if (!config.enabled) return;
         
         Identifier itemIdentifier = new Identifier(config.item);
@@ -31,7 +31,9 @@ public final class CatalystRegistry {
     }
 
     public static void registerFromConfig(String configKey, Catalyst catalyst) {
-        register(Disenchanter.getConfig().catalysts.get(configKey), catalyst);
+        DisenchanterConfig.CatalystConfig config = Disenchanter.getConfig().catalysts.get(configKey);
+        if ((config.item == "default") || (config.item == null) || (config.item == "")) config.item = configKey;
+        register(config, catalyst);
     }
 
     public static Catalyst get(ItemStack stack) {

--- a/src/main/java/com/glisco/disenchanter/catalyst/CatalystRegistry.java
+++ b/src/main/java/com/glisco/disenchanter/catalyst/CatalystRegistry.java
@@ -5,6 +5,7 @@ import com.glisco.disenchanter.compat.config.DisenchanterConfig;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.registry.Registry;
+import net.minecraft.util.Identifier;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -16,15 +17,21 @@ public final class CatalystRegistry {
 
     private static final Map<Item, CatalystEntry> REGISTRY = new HashMap<>();
 
-    public static void register(Item item, Catalyst catalyst, DisenchanterConfig.CatalystConfig config) {
-        if (REGISTRY.containsKey(item)) throw new IllegalArgumentException("Attempted to register catalyst for item " + item + "twice");
+    public static void register( DisenchanterConfig.CatalystConfig config, Catalyst catalyst) {
         if (!config.enabled) return;
+        
+        Identifier itemIdentifier = new Identifier(config.item);
+
+        Item item = Registry.ITEM.get(itemIdentifier);
+
+        if (item == null) throw new IllegalArgumentException("Attempted to register catalyst for unknown item " + itemIdentifier);
+        if (REGISTRY.containsKey(item)) throw new IllegalArgumentException("Attempted to register catalyst for item " + item + "twice");
 
         REGISTRY.put(item, new CatalystEntry(catalyst, config.required_item_count));
     }
 
-    public static void registerFromConfig(Item item, Catalyst catalyst) {
-        register(item, catalyst, Disenchanter.getConfig().catalysts.get(Registry.ITEM.getId(item).toString()));
+    public static void registerFromConfig(String configKey, Catalyst catalyst) {
+        register(Disenchanter.getConfig().catalysts.get(configKey), catalyst);
     }
 
     public static Catalyst get(ItemStack stack) {

--- a/src/main/java/com/glisco/disenchanter/catalyst/Catalysts.java
+++ b/src/main/java/com/glisco/disenchanter/catalyst/Catalysts.java
@@ -16,16 +16,16 @@ import java.util.Objects;
 public class Catalysts {
 
     public static void registerDefaults() {
-        CatalystRegistry.registerFromConfig(Items.EMERALD, new Emerald());
-        CatalystRegistry.registerFromConfig(Items.DIAMOND, new Diamond());
-        CatalystRegistry.registerFromConfig(Items.ENDER_PEARL, new EnderPearl());
-        CatalystRegistry.registerFromConfig(Items.HEART_OF_THE_SEA, new HeartOfTheSea());
-        CatalystRegistry.registerFromConfig(Items.AMETHYST_SHARD, new AmethystShard());
-        CatalystRegistry.registerFromConfig(Items.NETHER_STAR, new NetherStar());
-        CatalystRegistry.registerFromConfig(Items.EXPERIENCE_BOTTLE, new ExperienceBottle());
+        CatalystRegistry.registerFromConfig("minecraft:emerald", new TwoRandomEnchantmentsCatalyst());
+        CatalystRegistry.registerFromConfig("minecraft:diamond", new FirstAndTwoRandomEnchantmentsCatalyst());
+        CatalystRegistry.registerFromConfig("minecraft:ender_pearl", new RandomEnchantmentItemPreservedDamagedCatalyst());
+        CatalystRegistry.registerFromConfig("minecraft:heart_of_the_sea", new AllEnchantmentsDownOneLevelCatalyst());
+        CatalystRegistry.registerFromConfig("minecraft:amethyst_shard", new FirstEnchantmentItemPreservedCatalyst());
+        CatalystRegistry.registerFromConfig("minecraft:nether_star", new AllEnchantmentsItemPreservedCatalyst());
+        CatalystRegistry.registerFromConfig("minecraft:experience_bottle", new HighestLevelEnchantmentsCatalyst());
     }
 
-    public static class Emerald implements Catalyst {
+    public static class TwoRandomEnchantmentsCatalyst implements Catalyst {
 
         @Override
         public ItemStack generateOutput(ItemStack input, Random random) {
@@ -43,7 +43,7 @@ public class Catalysts {
         }
     }
 
-    public static class Diamond implements Catalyst {
+    public static class FirstAndTwoRandomEnchantmentsCatalyst implements Catalyst {
 
         @Override
         public ItemStack generateOutput(ItemStack input, Random random) {
@@ -64,7 +64,7 @@ public class Catalysts {
         }
     }
 
-    public static class EnderPearl implements Catalyst {
+    public static class RandomEnchantmentItemPreservedDamagedCatalyst implements Catalyst {
 
         @Nullable
         private EnchantmentLevelEntry enchantmentCache = null;
@@ -97,7 +97,7 @@ public class Catalysts {
         }
     }
 
-    public static class HeartOfTheSea implements Catalyst {
+    public static class AllEnchantmentsDownOneLevelCatalyst implements Catalyst {
 
         @Override
         public ItemStack generateOutput(ItemStack input, Random random) {
@@ -111,7 +111,7 @@ public class Catalysts {
         }
     }
 
-    public static class AmethystShard implements Catalyst {
+    public static class FirstEnchantmentItemPreservedCatalyst implements Catalyst {
 
         @Override
         public ItemStack transformInput(ItemStack input, Random random) {
@@ -132,7 +132,7 @@ public class Catalysts {
         }
     }
 
-    public static class NetherStar implements Catalyst {
+    public static class AllEnchantmentsItemPreservedCatalyst implements Catalyst {
 
         @Override
         public ItemStack transformInput(ItemStack input, Random random) {
@@ -151,7 +151,7 @@ public class Catalysts {
         }
     }
 
-    public static class ExperienceBottle implements Catalyst {
+    public static class HighestLevelEnchantmentsCatalyst implements Catalyst {
 
         @Override
         public ItemStack generateOutput(ItemStack input, Random random) {

--- a/src/main/java/com/glisco/disenchanter/compat/config/DisenchanterConfig.java
+++ b/src/main/java/com/glisco/disenchanter/compat/config/DisenchanterConfig.java
@@ -12,18 +12,23 @@ public class DisenchanterConfig implements ConfigData {
     public Map<String, CatalystConfig> catalysts = new HashMap<>();
 
     public DisenchanterConfig() {
-        catalysts.put("minecraft:emerald", new CatalystConfig());
-        catalysts.put("minecraft:diamond", new CatalystConfig());
-        catalysts.put("minecraft:ender_pearl", new CatalystConfig());
-        catalysts.put("minecraft:heart_of_the_sea", new CatalystConfig());
-        catalysts.put("minecraft:amethyst_shard", new CatalystConfig());
-        catalysts.put("minecraft:nether_star", new CatalystConfig());
-        catalysts.put("minecraft:experience_bottle", new CatalystConfig());
+        catalysts.put("minecraft:emerald", new CatalystConfig("minecraft:emerald"));
+        catalysts.put("minecraft:diamond", new CatalystConfig("minecraft:diamond"));
+        catalysts.put("minecraft:ender_pearl", new CatalystConfig("minecraft:ender_pearl"));
+        catalysts.put("minecraft:heart_of_the_sea", new CatalystConfig("minecraft:heart_of_the_sea"));
+        catalysts.put("minecraft:amethyst_shard", new CatalystConfig("minecraft:amethyst_shard"));
+        catalysts.put("minecraft:nether_star", new CatalystConfig("minecraft:nether_star"));
+        catalysts.put("minecraft:experience_bottle", new CatalystConfig("minecraft:experience_bottle"));
     }
 
     public static class CatalystConfig {
         public boolean enabled = true;
+        public String item;
         public int required_item_count = 1;
+
+        CatalystConfig(String item_name) {
+            item = item_name;
+        }
     }
 
 }

--- a/src/main/java/com/glisco/disenchanter/compat/config/DisenchanterConfig.java
+++ b/src/main/java/com/glisco/disenchanter/compat/config/DisenchanterConfig.java
@@ -12,23 +12,19 @@ public class DisenchanterConfig implements ConfigData {
     public Map<String, CatalystConfig> catalysts = new HashMap<>();
 
     public DisenchanterConfig() {
-        catalysts.put("minecraft:emerald", new CatalystConfig("minecraft:emerald"));
-        catalysts.put("minecraft:diamond", new CatalystConfig("minecraft:diamond"));
-        catalysts.put("minecraft:ender_pearl", new CatalystConfig("minecraft:ender_pearl"));
-        catalysts.put("minecraft:heart_of_the_sea", new CatalystConfig("minecraft:heart_of_the_sea"));
-        catalysts.put("minecraft:amethyst_shard", new CatalystConfig("minecraft:amethyst_shard"));
-        catalysts.put("minecraft:nether_star", new CatalystConfig("minecraft:nether_star"));
-        catalysts.put("minecraft:experience_bottle", new CatalystConfig("minecraft:experience_bottle"));
+        catalysts.put("minecraft:emerald", new CatalystConfig());
+        catalysts.put("minecraft:diamond", new CatalystConfig());
+        catalysts.put("minecraft:ender_pearl", new CatalystConfig());
+        catalysts.put("minecraft:heart_of_the_sea", new CatalystConfig());
+        catalysts.put("minecraft:amethyst_shard", new CatalystConfig());
+        catalysts.put("minecraft:nether_star", new CatalystConfig());
+        catalysts.put("minecraft:experience_bottle", new CatalystConfig());
     }
 
     public static class CatalystConfig {
         public boolean enabled = true;
-        public String item;
+        public String item = "default";
         public int required_item_count = 1;
-
-        CatalystConfig(String item_name) {
-            item = item_name;
-        }
     }
 
 }


### PR DESCRIPTION
Add the ability to change the catalyst item in config. Also renames the catalyst effects to better reflect the effects (the config keys understandably stay the same for compatibility purposes).

Have not tested it yet with old config (or at all)