### PR TITLE
Backport bugfix and config change to 1.20 base

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,10 @@ plugins {
 version = "${project.mod_version}+${project.minecraft_base_version}"
 group = project.maven_group
 
+base {
+    archivesName = project.archives_base_name
+}
+
 repositories {
     maven { url "https://maven.shedaniel.me/" }
     maven { url "https://maven.terraformersmc.com/" }

--- a/src/main/java/com/glisco/disenchanter/DisenchanterScreenHandler.java
+++ b/src/main/java/com/glisco/disenchanter/DisenchanterScreenHandler.java
@@ -80,8 +80,10 @@ public class DisenchanterScreenHandler extends ScreenHandler {
         if (contOpt.isEmpty()) return;
 
         final var world = contOpt.get();
-        final var catalyst = CatalystRegistry.get(inventory.getStack(2));
+        final var catalystStack = inventory.getStack(2);
+        if (!Disenchanter.getConfig().allowDisenchantingWithoutCatalyst && catalystStack.isEmpty()) return;
 
+        final var catalyst = CatalystRegistry.get(catalystStack);
         var processedInput = catalyst.transformInput(inventory.getStack(0).copy(), world.random);
 
         inventory.setStack(3, catalyst.generateOutput(inventory.getStack(0).copy(), world.random));

--- a/src/main/java/com/glisco/disenchanter/catalyst/Catalysts.java
+++ b/src/main/java/com/glisco/disenchanter/catalyst/Catalysts.java
@@ -71,8 +71,6 @@ public class Catalysts {
 
         @Override
         public ItemStack transformInput(ItemStack input, Random random) {
-            input.damage(500, random, null);
-
             var levelMap = EnchantmentHelper.fromNbt(input.getEnchantments());
             var enchantments = new ArrayList<>(levelMap.keySet());
 
@@ -82,6 +80,10 @@ public class Catalysts {
             levelMap.remove(removedEnchantment);
             EnchantmentHelper.set(levelMap, input);
 
+            int damage = input.getDamage() + 500;
+            if (damage >= input.getMaxDamage()) return ItemStack.EMPTY;
+
+            input.setDamage(damage);
             return input;
         }
 

--- a/src/main/java/com/glisco/disenchanter/client/DisenchanterScreen.java
+++ b/src/main/java/com/glisco/disenchanter/client/DisenchanterScreen.java
@@ -47,7 +47,7 @@ public class DisenchanterScreen extends HandledScreen<DisenchanterScreenHandler>
 
     @Override
     protected void handledScreenTick() {
-        this.validCatalyst = !this.handler.getSlot(2).hasStack() || CatalystRegistry.get(this.handler.getSlot(2).getStack()) != Catalyst.DEFAULT;
+        this.validCatalyst = (Disenchanter.getConfig().allowDisenchantingWithoutCatalyst && !this.handler.getSlot(2).hasStack()) || CatalystRegistry.get(this.handler.getSlot(2).getStack()) != Catalyst.DEFAULT;
     }
 
     public int getBaseX() {

--- a/src/main/java/com/glisco/disenchanter/compat/config/DisenchanterConfig.java
+++ b/src/main/java/com/glisco/disenchanter/compat/config/DisenchanterConfig.java
@@ -10,6 +10,7 @@ import java.util.Map;
 public class DisenchanterConfig implements ConfigData {
 
     public Map<String, CatalystConfig> catalysts = new HashMap<>();
+    public boolean allowDisenchantingWithoutCatalyst = true;
 
     public DisenchanterConfig() {
         catalysts.put("minecraft:emerald", new CatalystConfig());


### PR DESCRIPTION
My modpack is running 1.20.1 rather than latest 1.20.x, so is unable to use the more recent builds. This PR backports two later changes that I found important to the older branch:

* The bugfix added in fde2ff9a3b2673e5b342b74e2c11cafc16bbd72c is pretty critical to game balancing, since without it players are able to extract all enchants from an item with no penalty.
* f4428b43fc5dc1d934381efdef8d2259404c0115 is useful in being able to add some additional cost.