### PR TITLE
fix recipe and tooltip name

### DIFF
--- a/src/main/resources/assets/disenchanter/lang/en_us.json
+++ b/src/main/resources/assets/disenchanter/lang/en_us.json
@@ -1,8 +1,9 @@
 {
-  "block.disenchanter.disenchanter" : "Disenchanter",
-  "disenchanter.gui.title" : "Disenchanter",
-  "disenchanter.gui.button" : "Disenchant",
-  "disenchanter.rei.title" : "Catalyst",
+  "block.disenchanter.disenchanter": "Disenchanter",
+  "item.disenchanter.disenchanter": "Disenchanter",
+  "disenchanter.gui.title": "Disenchanter",
+  "disenchanter.gui.button": "Disenchant",
+  "disenchanter.rei.title": "Catalyst",
 
   "disenchanter.catalyst.emerald": "Recovers two random enchantments. Destroys the item",
   "disenchanter.catalyst.diamond": "Recovers the first + two random enchantments. Destroys the item",

--- a/src/main/resources/data/disenchanter/recipe/disenchanter.json
+++ b/src/main/resources/data/disenchanter/recipe/disenchanter.json
@@ -6,15 +6,9 @@
     "OOO"
   ],
   "key": {
-    "O": {
-      "item": "minecraft:crying_obsidian"
-    },
-    "E": {
-      "item": "minecraft:emerald_block"
-    },
-    "W": {
-      "item": "minecraft:black_carpet"
-    }
+    "O": "minecraft:crying_obsidian",
+    "E": "minecraft:emerald_block",
+    "W": "minecraft:black_carpet"
   },
   "result": {
     "id": "disenchanter:disenchanter",


### PR DESCRIPTION
If the recipe so it works in 1.21.2 onwards, as well as fix the tooltip name from displaying as item.disenchanter.disenchanter.